### PR TITLE
fix: exclude protos in build directory

### DIFF
--- a/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
+++ b/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
@@ -48,6 +48,7 @@ public class CodeStylePlugin implements Plugin<Project> {
         "misc,",
         format -> {
           format.target("*.md", "**/*.proto", ".gitignore");
+          format.targetExclude("build/**/*.proto");
           format.indentWithSpaces();
           format.trimTrailingWhitespace();
           format.endWithNewline();


### PR DESCRIPTION
Leads to formatting errors in the proto files coming from dependencies

https://github.com/hypertrace/hypertrace-ingester/pull/149/checks?check_run_id=2067962684