### PR TITLE
Using ktfmt instead of ktlint

### DIFF
--- a/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
+++ b/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
@@ -8,7 +8,6 @@ import org.gradle.api.Project;
 import org.gradle.api.plugins.PluginContainer;
 
 import javax.annotation.Nonnull;
-import java.util.HashMap;
 
 public class CodeStylePlugin implements Plugin<Project> {
 

--- a/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
+++ b/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
@@ -1,12 +1,14 @@
 package org.hypertrace.gradle.code.style;
 
+import com.diffplug.gradle.spotless.KotlinGradleExtension;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import com.diffplug.gradle.spotless.SpotlessPlugin;
-import java.util.HashMap;
-import javax.annotation.Nonnull;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.plugins.PluginContainer;
+
+import javax.annotation.Nonnull;
+import java.util.HashMap;
 
 public class CodeStylePlugin implements Plugin<Project> {
 
@@ -34,15 +36,7 @@ public class CodeStylePlugin implements Plugin<Project> {
         });
 
     spotlessExtension.kotlinGradle(
-        format -> format
-            .ktlint()
-            .userData(
-                new HashMap<String, String>() {
-                  {
-                    put("indent_size", "2");
-                    put("continuation_indent_size", "2");
-                  }
-                }));
+        KotlinGradleExtension::ktfmt);
 
     spotlessExtension.format(
         "misc,",


### PR DESCRIPTION
## Description
There seems to be an issue with ktlint which doesn't format the gradle.kts files. So using ktfmt instead.


### Testing
Tested manually by publishing to mavenLocal and using it in other repos

### Checklist:
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules


