### PR TITLE
Using 0.41.0 version of ktlint

### DIFF
--- a/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
+++ b/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
@@ -35,7 +35,7 @@ public class CodeStylePlugin implements Plugin<Project> {
 
     spotlessExtension.kotlinGradle(
         format -> format
-            .ktlint()
+            .ktlint("0.41.0")
             .userData(
                 new HashMap<String, String>() {
                   {


### PR DESCRIPTION
## Description
Formatting on gradle.kts file was broken on the default ktlint version(0.35.0). Specifically using the latest version 0.41.0 fixed it.


### Testing
Published to mavenLocal and testing on other repos

### Checklist:
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules

