### PR TITLE
chore: Fix depcheck errors

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,6 +19,8 @@ dependencies {
   api("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
   constraints {
     implementation("com.squareup.okio:okio:3.4.0")
+    implementation("org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r")
+    implementation("org.eclipse.platform:org.eclipse.osgi:3.18.500")
   }
 }
 


### PR DESCRIPTION
Add constraints on transitive dependencies of `spotless-plugin-gradle` to use non-vulnerable versions as per depcheck failures.

```
org.eclipse.platform:org.eclipse.osgi:3.18.300 -> 3.18.500
org.eclipse.jgit:org.eclipse.jgit:6.7.0.202309050840-r -> 6.8.0.202311291450-r
```