### PR TITLE
Format .proto files with spotlessApply

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
   id("org.hypertrace.ci-utils-plugin") version "0.3.0"
   id("org.hypertrace.publish-plugin") version "1.0.4"
   id("org.owasp.dependencycheck") version "8.4.0"
+  id("com.diffplug.spotless") version "7.0.0"
 }
 
 group = "org.hypertrace.gradle.code.style"
@@ -16,12 +17,8 @@ java {
 }
 
 dependencies {
-  api("com.diffplug.spotless:spotless-plugin-gradle:6.25.0")
-  constraints {
-    implementation("com.squareup.okio:okio:3.4.0")
-    implementation("org.eclipse.jgit:org.eclipse.jgit:6.8.0.202311291450-r")
-    implementation("org.eclipse.platform:org.eclipse.osgi:3.18.500")
-  }
+  api("com.diffplug.spotless:spotless-plugin-gradle:7.0.0")
+  implementation("build.buf:buf-gradle-plugin:0.10.0")
 }
 
 gradlePlugin {
@@ -42,4 +39,15 @@ dependencyCheck {
   suppressionFile = "owasp-suppressions.xml"
   scanConfigurations.add("runtimeClasspath")
   failBuildOnCVSS = 3.0F
+}
+
+spotless {
+  java {
+    importOrder()
+    removeUnusedImports()
+    googleJavaFormat("1.17.0")
+  }
+  kotlin {
+    ktlint()
+  }
 }

--- a/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
+++ b/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
@@ -1,10 +1,13 @@
 package org.hypertrace.gradle.code.style;
 
+import build.buf.gradle.BufExtension;
+import build.buf.gradle.BufPlugin;
+import build.buf.gradle.BufSupportKt;
 import com.diffplug.gradle.spotless.SpotlessExtension;
 import com.diffplug.gradle.spotless.SpotlessPlugin;
-
+import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nonnull;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
@@ -20,13 +23,14 @@ public class CodeStylePlugin implements Plugin<Project> {
   private void configureCodeStyle(Project project) {
     PluginContainer pluginContainer = project.getPlugins();
     pluginContainer.apply(SpotlessPlugin.class);
-
-    SpotlessExtension spotlessExtension =
-        project.getExtensions().getByType(SpotlessExtension.class);
-    configureFormatting(spotlessExtension);
+    pluginContainer.apply(BufPlugin.class);
+    configureFormatting(project);
   }
 
-  private void configureFormatting(SpotlessExtension spotlessExtension) {
+  private void configureFormatting(Project project) {
+    SpotlessExtension spotlessExtension =
+        project.getExtensions().getByType(SpotlessExtension.class);
+
     spotlessExtension.java(
         format -> {
           format.importOrder();
@@ -36,26 +40,34 @@ public class CodeStylePlugin implements Plugin<Project> {
         });
 
     spotlessExtension.kotlinGradle(
-        format ->
-        {
-            try {
-                format
-                    .ktlint("0.50.0")
-                    .editorConfigOverride(
-                        new HashMap<String, Object>() {
-                          {
-                            put("indent_size", "2");
-                          }
-                        });
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
+        format -> {
+          try {
+            format.ktlint("0.50.0").editorConfigOverride(Map.of("indent_size", "2"));
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
         });
+
+    BufExtension bufExtension = project.getExtensions().getByType(BufExtension.class);
+    spotlessExtension.protobuf(
+        format -> {
+          File bufBinary =
+              project
+                  .getConfigurations()
+                  .getByName(BufSupportKt.BUF_BINARY_CONFIGURATION_NAME)
+                  .getSingleFile();
+          if (!bufBinary.canExecute()) {
+            bufBinary.setExecutable(true);
+          }
+          format.buf(bufExtension.getToolVersion()).pathToExe(bufBinary.getAbsolutePath());
+        });
+    bufExtension.setEnforceFormat(false);
+
     spotlessExtension.format(
         "misc",
         format -> {
-          format.target("*.md", "src/**/*.proto", ".gitignore", "*.yaml");
-          format.indentWithSpaces(2);
+          format.target("*.md", ".gitignore", "*.yaml");
+          format.leadingTabsToSpaces(2);
           format.trimTrailingWhitespace();
           format.endWithNewline();
         });


### PR DESCRIPTION
- Use the buf-gradle-plugin to download the correct buf binary automatically and configure spotless to use it
- Update spotless plugin to `7.0.0` ([released today](https://plugins.gradle.org/plugin/com.diffplug.gradle.spotless))
- Use spotless to format files in this repo
