### PR TITLE
fix: flip tabs and spaces

### DIFF
--- a/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
+++ b/src/main/java/org/hypertrace/gradle/code/style/CodeStylePlugin.java
@@ -55,7 +55,7 @@ public class CodeStylePlugin implements Plugin<Project> {
         "misc",
         format -> {
           format.target("*.md", "src/**/*.proto", ".gitignore", "*.yaml");
-          format.leadingSpacesToTabs(2);
+          format.leadingTabsToSpaces(2);
           format.trimTrailingWhitespace();
           format.endWithNewline();
         });


### PR DESCRIPTION
## Description
Mistake in previous PR on deprecation fix - accidentally flipped spaces to tabs rather than tabs to spaces...
